### PR TITLE
get request for forecast based a city, state

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::ForecastController < ApplicationController
+  def show
+    render json: forecast_data(params[:location])
+  end
+
+  private
+
+  def forecast_data(location)
+    geolocation = GoogleGeolocationService.new.get_geocode(location)
+    lat_lng_string = geolocation[:results][0][:geometry][:location].values.join(',')
+    forecast = DarkskyService.new.get_forecast(lat_lng_string)
+
+    forecast_serializer = ForecastSerializer.new(geolocation, forecast)
+    forecast_serializer.get_forecast
+  end
+end

--- a/app/serializer/forecast_serializer.rb
+++ b/app/serializer/forecast_serializer.rb
@@ -1,0 +1,37 @@
+class ForecastSerializer
+  def initialize(geolocation, forecast)
+    @geolocation = geolocation
+    @forecast = forecast
+  end
+
+  def get_forecast
+    address = @geolocation[:results][0][:formatted_address]
+    daily = daily_forecasts(@forecast[:daily][:data])
+    hourly = hourly_forecasts(@forecast[:hourly][:data])
+    current = current_weather(@forecast[:currently])
+    forecast_response(address, daily, hourly, current)
+  end
+
+  private
+
+  def forecast_response(address, daily, hourly, current)
+    {
+      "address": address,
+      "current_weather": JSON.parse(current),
+      "daily_forecast": {"data": JSON.parse(daily) },
+      "hourly_forecast": {"data": JSON.parse(hourly) }
+    }
+  end
+
+  def current_weather(data)
+    data.to_json(only: [:time, :summary, :icon, :precipProbability, :precipType, :temperature, :apparentTemperature, :humidity, :uvIndex, :visibility])
+  end
+
+  def hourly_forecasts(data)
+    data.map.to_json(only: [:time, :summary, :icon, :temperature])
+  end
+
+  def daily_forecasts(data)
+    data.map.to_json(only: [:time, :icon, :precipProbability, :precipType, :temperatureHigh, :temperatureLow])
+  end
+end

--- a/app/services/darksky_service.rb
+++ b/app/services/darksky_service.rb
@@ -5,7 +5,8 @@ class DarkskyService
 
   def get_forecast(lat_lng)
     path = "forecast/#{@api_key}/#{lat_lng}"
-    get_json(path)
+    params = { exclude: 'minutely,alerts,flags' }
+    get_json(path, params)
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get 'forecast', to: 'forecast#show'
+    end
+  end
 end

--- a/spec/fixtures/get_forecast_response.json
+++ b/spec/fixtures/get_forecast_response.json
@@ -1,0 +1,119 @@
+{
+  "address": "Denver, CO, USA",
+  "current_weather": {
+    "time": 1564267379,
+    "summary": "Mostly Cloudy",
+    "icon": "partly-cloudy-day",
+    "precipProbability": 0.19,
+    "precipType": "rain",
+    "temperature": 84.67,
+    "apparentTemperature": 84.67,
+    "humidity": 0.32,
+    "uvIndex": 3,
+    "visibility": 3.664
+  },
+  "daily_forecast": {
+    "data": [
+      {
+        "time": 1564207200,
+        "icon": "rain",
+        "precipProbability": 0.45,
+        "precipType": "rain",
+        "temperatureHigh": 87.48,
+        "temperatureLow": 68.5
+      },
+      {
+        "time": 1564293600,
+        "icon": "rain",
+        "precipProbability": 0.45,
+        "precipType": "rain",
+        "temperatureHigh": 87.48,
+        "temperatureLow": 68.5
+      },
+      {
+        "time": 1564380000,
+        "icon": "rain",
+        "precipProbability": 0.45,
+        "precipType": "rain",
+        "temperatureHigh": 87.48,
+        "temperatureLow": 68.5
+      },
+      {
+        "time": 1564466400,
+        "icon": "rain",
+        "precipProbability": 0.45,
+        "precipType": "rain",
+        "temperatureHigh": 87.48,
+        "temperatureLow": 68.5
+      },
+      {
+        "time": 1564552800,
+        "icon": "rain",
+        "precipProbability": 0.45,
+        "precipType": "rain",
+        "temperatureHigh": 87.48,
+        "temperatureLow": 68.5
+      },
+      {
+        "time": 1564639200,
+        "icon": "rain",
+        "precipProbability": 0.45,
+        "precipType": "rain",
+        "temperatureHigh": 87.48,
+        "temperatureLow": 68.5
+      }
+    ]
+  },
+  "hourly_forecast": {
+    "data": [
+      {
+        "time": 1564264800,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564268400,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564272000,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564275600,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564279200,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564282800,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564286400,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      },
+      {
+        "time": 1564290000,
+        "summary": "Mostly Cloudy",
+        "icon": "partly-cloudy-day",
+        "temperature": 86.68
+      }
+    ]
+  }
+}

--- a/spec/requests/forecast_controller_spec.rb
+++ b/spec/requests/forecast_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'forecast controller' do
+  describe 'show' do
+    before :each do
+      get "/api/v1/forecast?location=denver,co"
+    end
+    it 'should return a status of 200' do
+      expect(response).to be_successful
+    end
+
+    it 'should return JSON of weather by city' do
+      data = JSON.parse(response.body, symbolize_names: true)
+
+      expect(data).to be_an(Hash)
+      expect(data[:address]).to eq('Denver, CO, USA')
+
+      current_weather = data[:current_weather]
+      expect(current_weather[:time]).to be_kind_of(Integer)
+      expect(current_weather[:summary]).to be_kind_of(String)
+      expect(current_weather[:icon]).to be_kind_of(String)
+      expect(current_weather[:precipProbability] >= 0).to eq(true)
+      # expect(current_weather).to include(:precipType)
+      expect(current_weather[:temperature]).to be_kind_of(Float)
+      expect(current_weather[:apparentTemperature]).to be_kind_of(Float)
+      expect(current_weather[:humidity]).to be_kind_of(Float)
+      expect(current_weather[:uvIndex]).to be_kind_of(Integer)
+      expect(current_weather[:visibility]).to be_kind_of(Float)
+
+      daily_forecast = data[:daily_forecast][:data][0]
+      expect(data[:daily_forecast][:data].length > 4).to eq(true)
+      expect(daily_forecast[:time]).to be_kind_of(Integer)
+      expect(daily_forecast[:icon]).to be_kind_of(String)
+      expect(daily_forecast).to include(:precipProbability)
+      expect(daily_forecast).to include(:precipType)
+      expect(daily_forecast[:temperatureHigh]).to be_kind_of(Float)
+      expect(daily_forecast[:temperatureLow]).to be_kind_of(Float)
+
+      hourly_forcast = data[:hourly_forecast][:data][0]
+      expect(data[:hourly_forecast][:data].length > 7).to eq(true)
+      expect(hourly_forcast[:time]).to be_kind_of(Integer)
+      expect(hourly_forcast[:summary]).to be_kind_of(String)
+      expect(hourly_forcast[:icon]).to be_kind_of(String)
+      expect(hourly_forcast[:temperature]).to be_kind_of(Float)
+    end
+  end
+
+end

--- a/spec/services/darksky_service_spec.rb
+++ b/spec/services/darksky_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DarkskyService do
     expect(todays_weather[:temperatureLow]).to be_kind_of(Float)
     expect(todays_weather[:summary]).to be_kind_of(String)
     expect(todays_weather[:icon]).to be_kind_of(String)
-    expect(todays_weather[:precipIntensityMax]).to be_kind_of(Float)
+    expect(todays_weather[:precipProbability]).to be_kind_of(Float)
     expect(todays_weather[:precipType]).to be_kind_of(String)
 
     daily_weather = response[:daily][:data]


### PR DESCRIPTION
adds a route GET /api/v1/forecast?location=denver,co which takes in a location and returns json of the forecast. 
adds forecast controller with show action.
adds a ForecastSerializer to return the formatted JSON


resolves #2 